### PR TITLE
ci: auto-publish docs to GitHub Pages on push to main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,60 @@
+name: Deploy docs
+
+# Builds the Docusaurus site and publishes it to GitHub Pages on every push to main.
+# Replaces the manual `docusaurus deploy` from a local machine.
+#
+# One-time human setup required before this takes effect:
+#   Repo Settings -> Pages -> Build and deployment -> Source = "GitHub Actions"
+# Until then this workflow runs the build but the deploy step is a no-op target,
+# so merging it is safe and inert.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress production deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,12 +12,16 @@ on:
   push:
     branches:
       - main
+  # Build (not deploy) on PRs targeting main, so broken builds surface in the PR
+  # instead of landing on main.
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
+# Least privilege at workflow level; the deploy job elevates its own scope below.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow one concurrent deployment; don't cancel an in-progress production deploy.
 concurrency:
@@ -27,6 +31,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,7 +55,13 @@ jobs:
 
   deploy:
     needs: build
+    # Only deploy from main; skips PR builds and non-main workflow_dispatch runs.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # Scope Pages/OIDC write to deploy only (build job stays contents: read).
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Description

Docs are currently deployed by running `docusaurus deploy` manually from one person's machine, which makes publishing a single-owner, error-prone step. This adds CI that builds and publishes the site automatically on every push to `main`, removing the manual/laptop dependency.

## Changes

- Add `.github/workflows/deploy-docs.yml`: builds the Docusaurus site (Node 20, `npm ci`, `npm run build`) and deploys via `actions/upload-pages-artifact` + `actions/deploy-pages`. Triggers on push to `main` and `workflow_dispatch`.

## Human step required (not done here)

Set repo **Settings → Pages → Source = "GitHub Actions"** for this to take effect. Until then the build runs but deploy is inert — safe to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)