### PR TITLE
UpdateWorkflowSecrets: add Jenkins dependency-update caller workflow

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -1,0 +1,18 @@
+name: Dependency Update
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-deps:
+    uses: Xemelgo/.github/.github/workflows/update-dependencies-with-codemod.yml@main
+    with:
+      package_name: ''
+      branch_name: 'deps/consolidated-update-with-migrations'
+      dry_run: false
+      team_reviewers: 'Xemelgo/edge-ingestion-team'
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      XEMELGO_DOTGITHUB_READ_PAT: ${{ secrets.XEMELGO_DOTGITHUB_READ_PAT }}


### PR DESCRIPTION
Adds the dependency-update.yml caller workflow so the Jenkins dependency-update pipeline can trigger automated dependency upgrades in this repo. Merge to opt this repo into the pipeline.

## Required repository secrets

Before merging, add these secrets to the repo (Settings → Secrets and variables → Actions):

- [x] `OPENAI_API_KEY`
- [x] `JIRA_EMAIL`
- [x] `JIRA_API_TOKEN`
- [x] `XEMELGO_DOTGITHUB_READ_PAT`